### PR TITLE
【調整中】[ その他 ][ 7.0 対応 ] メタボックスにRTC互換フラグを追加

### DIFF
--- a/inc/showcase/package/class-vk-showcase-custom-fields.php
+++ b/inc/showcase/package/class-vk-showcase-custom-fields.php
@@ -29,7 +29,8 @@ class VK_Showcase_Custom_Fields {
 			array( __CLASS__,  'add_fields' ),
 			'post',
 			'normal',
-			'default'
+			'default',
+			array( '__back_compat_meta_box' => true )
 		);
 	}
 


### PR DESCRIPTION
## 概要

WordPress 7.0 で導入予定のリアルタイムコラボレーション（RTC）機能に対応するため、`add_meta_box` に `__back_compat_meta_box` フラグを追加しました。

## 変更内容

- サイト制作情報メタボックス（`vk_showcase_site_infomation`）の `add_meta_box` 呼び出しに `array( '__back_compat_meta_box' => true )` を追加

### テスト手順

#### 前提条件
- WordPress Beta Tester プラグインで **WordPress 7.0 RC** にアップデートしていること
- VK Showcase が有効化されていること
- 上記以外のプラグインを一時的に停止すること
- 管理者アカウントが2つあること

#### RTC 動作確認（WordPress 7.0 RC）

1. 管理画面 > 設定 > 投稿設定 で「Collaboration」を有効にする
2. User1 で投稿（または固定ページ）の編集画面を開く
   → ✓ サイト制作情報メタボックスが正常に表示される
3. User2 で別のブラウザ（またはシークレットウィンドウ）から同じ投稿を開く
   → ✓ RTC が有効になっている（右上にアバターが2つ表示される）
   → ✓ メタボックスが存在していても RTC がブロックされていないこと
4. User1 がタイトルや本文を変更する
   → ✓ User2 側にリアルタイムで反映されること

#### デグレ確認（WordPress 6.x）
1. WordPress Beta Tester プラグインで 6.x に戻す（または別環境で確認）
2. 投稿編集画面を開く
   → ✓ サイト制作情報メタボックスが正常に表示される
3. メタボックスで設定を変更し保存する
   → ✓ 設定が正常に保存される（既存動作に影響なし）

### レビューポイント（任意）
- 各 `add_meta_box()` の第7引数に `array( '__back_compat_meta_box' => true )` が正しく追加されているか
- 既存の引数が変更されていないか

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している（必要な場合）
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている

関連Issue: #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* **バグ修正**
  * カスタムフィールドのメタボックス機能におけるWordPress互換性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
